### PR TITLE
DATA URL FIX

### DIFF
--- a/data_service/api/auth.py
+++ b/data_service/api/auth.py
@@ -11,10 +11,17 @@ from fastapi import HTTPException, status
 
 def authorize_user(authorization_header):
     log = logging.getLogger(__name__)
-    try:
-        if os.environ.get('TOGGLE_AUTH', 'ON') == 'OFF':
+
+    if os.environ.get('TOGGLE_AUTH', 'ON') == 'OFF':
             log.info('Auth toggled off. Returning "default" as user_id.')
             return 'default'
+    if authorization_header is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Unauthorized. No token was provided"
+        )
+
+    try:
         JWT_token = authorization_header.removeprefix('Bearer ')
         public_key = os.environ['JWT_PUBLIC_KEY']
 

--- a/data_service/api/data_api.py
+++ b/data_service/api/data_api.py
@@ -68,12 +68,16 @@ def create_result_set_event_data(input_query: InputTimePeriodQuery,
     user_id = authorize_user(authorization)
     log.info(f"Authorized token for user: {user_id}")
 
-    result_filename = processor.process_event_request(input_query)
-    log.info(f'Filename with event result set: {result_filename}')
+    resultset_file_name = processor.process_event_request(input_query)
+    resultset_data_url = (
+        f"{settings.DATA_SERVICE_URL}/data/resultSet"
+        f"?file_name={resultset_file_name}"
+    )
+    log.info(f'Data url for event result set: {resultset_data_url}')
 
     return {
         'name': input_query.dataStructureName,
-        'resultSetFileName': result_filename
+        'dataUrl': resultset_data_url
     }
 
 
@@ -95,12 +99,16 @@ def create_result_set_status_data(input_query: InputTimeQuery,
     user_id = authorize_user(authorization)
     log.info(f"Authorized token for user: {user_id}")
 
-    result_filename = processor.process_status_request(input_query)
-    log.info(f'Filename with status result set: {result_filename}')
+    resultset_file_name = processor.process_status_request(input_query)
+    resultset_data_url = (
+        f"{settings.DATA_SERVICE_URL}/data/resultSet"
+        f"?file_name={resultset_file_name}"
+    )
+    log.info(f'Data url for status result set: {resultset_data_url}')
 
     return {
         'name': input_query.dataStructureName,
-        'resultSetFileName': result_filename
+        'dataUrl': resultset_data_url
     }
 
 
@@ -122,11 +130,15 @@ def create_result_set_fixed_data(input_query: InputFixedQuery,
     user_id = authorize_user(authorization)
     log.info(f"Authorized token for user: {user_id}")
 
-    result_filename = processor.process_fixed_request(input_query)
-    log.info(f'Filename with fixed result set: {result_filename}')
+    resultset_file_name = processor.process_fixed_request(input_query)
+    resultset_data_url = (
+        f"{settings.DATA_SERVICE_URL}/data/resultSet"
+        f"?file_name={resultset_file_name}"
+    )
+    log.info(f'data url for fixed result set: {resultset_data_url}')
 
     return {
         'name': input_query.dataStructureName,
-        'resultSetFileName': result_filename
+        'dataUrl': resultset_data_url
     }
 

--- a/tests/unit/api/test_data_api.py
+++ b/tests/unit/api/test_data_api.py
@@ -84,7 +84,7 @@ def test_data_event():
         headers={"Authorization": f"Bearer {VALID_JWT_TOKEN}"}
     )
     assert response.status_code == 200
-    assert FAKE_RESULT_FILE_NAME in response.json()['resultSetFileName']
+    assert FAKE_RESULT_FILE_NAME in response.json()['dataUrl']
 
 # /data/status
 def test_data_status():
@@ -94,7 +94,7 @@ def test_data_status():
         headers={"Authorization": f"Bearer {VALID_JWT_TOKEN}"}
     )
     assert response.status_code == 200
-    assert FAKE_RESULT_FILE_NAME in response.json()['resultSetFileName']
+    assert FAKE_RESULT_FILE_NAME in response.json()['dataUrl']
 
 # /data/fixed
 def test_data_fixed():
@@ -104,4 +104,4 @@ def test_data_fixed():
         headers={"Authorization": f"Bearer {VALID_JWT_TOKEN}"}
     )
     assert response.status_code == 200
-    assert FAKE_RESULT_FILE_NAME in response.json()['resultSetFileName']
+    assert FAKE_RESULT_FILE_NAME in response.json()['dataUrl']


### PR DESCRIPTION
# DATA URL FIX
return the complete data url as expected by microdata-metadata-service

### WHY?
* To match the interface as decided

## HOW?
* Generate a complete url from the generated filename + the configuration

## NOTES
* Also moved around some code, and added a None check in the auth module to give nicer feedback when authorization token is not present
* Tested this branch succesfully together with metadata-service
