### PR TITLE
Add OpenAPI description of Parquet format

### DIFF
--- a/application.py
+++ b/application.py
@@ -24,7 +24,30 @@ from data_service.core.filters import EmptyResultSetException
     Self-hosting JavaScript and CSS for docs
     https://fastapi.tiangolo.com/advanced/extending-openapi/#self-hosting-javascript-and-css-for-docs
 """
-data_service_app = FastAPI(docs_url=None, redoc_url=None)
+
+description = """
+The Parquet file format returned or produced by this service reported by `pq.read_schema(parquet_file).to_string()` is as follows:
+```
+format_version: 1.0
+unit_id: uint64
+-- field metadata --
+PARQUET:field_id: '1'
+value: string
+-- field metadata --
+PARQUET:field_id: '2'
+start_epoch_days: int16
+-- field metadata --
+PARQUET:field_id: '3'
+stop_epoch_days: int16
+-- field metadata --
+PARQUET:field_id: '4'
+```
+"""
+
+data_service_app = FastAPI(
+    title="Data service",
+    description=description
+)
 data_service_app.mount("/static", StaticFiles(directory="static"), name="static")
 
 data_service_app.include_router(data_router)


### PR DESCRIPTION
The client needs to know the format of the Parquet file that data-service produces.
The description will look like this:

![Screenshot 2022-01-12 at 09 32 15](https://user-images.githubusercontent.com/23167730/149092004-121bb90c-7954-41e2-8c2c-db6ea03d9562.png)
