### PR TITLE
remove_resultset_endpoint

### DIFF
--- a/data_service/api/data_api.py
+++ b/data_service/api/data_api.py
@@ -22,35 +22,6 @@ data_router = APIRouter()
 log = logging.getLogger(__name__)
 
 
-@data_router.get("/data/resultSet", responses={
-                 204: {}, 404: {"model": ErrorMessage}})
-def retrieve_result_set(file_name: str,
-                        authorization: str = Header(None),
-                        settings: config.BaseSettings = Depends(get_settings)):
-    """
-    Stream a generated result parquet file.
-    """
-    log.info(
-        f"Entering /data/resultSet with request for file name: {file_name}"
-    )
-    user_id = authorize_user(authorization)
-    log.info(f"Authorized token for user: {user_id}")
-
-    file_path = (
-        f"{settings.RESULTSET_DIR}/{file_name}"
-    )
-    if not os.path.isfile(file_path):
-        log.warning(f"No file found for path: {file_path}")
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail='Result set not found'
-        )
-    else:
-        return FileResponse(
-            file_path, media_type='application/octet-stream'
-        )
-
-
 @data_router.post("/data/event/generate-file",
                   responses={404: {"model": ErrorMessage}})
 def create_result_file_event(input_query: InputTimePeriodQuery,

--- a/tests/unit/api/test_data_api.py
+++ b/tests/unit/api/test_data_api.py
@@ -57,39 +57,6 @@ def setup(monkeypatch):
     )
 
 
-# /data/resultset
-def test_get_result_set_valid_request():
-    response = client.get(
-            "/data/resultSet?file_name=1234-1234-1234-1234.parquet",
-            headers={"Authorization": f"Bearer {VALID_JWT_TOKEN}"}
-    )
-    expected_response = open(
-        'tests/resources/resultset/1234-1234-1234-1234.parquet', 'rb'
-    ).read()
-
-    assert response.content == expected_response
-
-
-def test_get_result_set_not_found_dataset():
-    response = client.get(
-            "/data/resultSet?file_name=does-not-exist.parquet",
-            headers={"Authorization": f"Bearer {VALID_JWT_TOKEN}"}
-    )
-
-    assert response.status_code == 404
-    assert response.json() == {"detail": "Result set not found"}
-
-
-def test_get_result_set_invalid_signature_request():
-    response = client.get(
-            "/data/resultSet?file_name=1234-1234-1234-1234.parquet",
-            headers={"Authorization": f"Bearer {INVALID_JWT_TOKEN}"}
-    )
-
-    assert response.status_code == 401
-    assert "Unauthorized" in response.json()["detail"]
-
-
 # /data/event
 def test_data_event_generate_file():
     response = client.post(


### PR DESCRIPTION
# Remove data/resultSet endpoint

After implementing the stream endpoints in addition to mainly using the data/generate-file endpoints in the foreseeable future, we might as well delete this endpoint.