### PR TITLE
faster streaming endpoints

### DIFF
--- a/data_service/api/data_api.py
+++ b/data_service/api/data_api.py
@@ -2,7 +2,7 @@ import logging
 import os
 import io
 from fastapi import APIRouter, Depends, Header
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import PlainTextResponse
 from fastapi import HTTPException, status
 
 import pyarrow as pa
@@ -114,8 +114,8 @@ def stream_result_event(input_query: InputTimePeriodQuery,
     result_data = processor.process_event_request(input_query)
     buffer_stream = pa.BufferOutputStream()
     pq.write_table(result_data, buffer_stream)
-    return StreamingResponse(
-        io.BytesIO(buffer_stream.getvalue().to_pybytes())
+    return PlainTextResponse(
+        buffer_stream.getvalue().to_pybytes()
     )
 
 
@@ -136,8 +136,8 @@ def stream_result_status(input_query: InputTimeQuery,
     result_data = processor.process_status_request(input_query)
     buffer_stream = pa.BufferOutputStream()
     pq.write_table(result_data, buffer_stream)
-    return StreamingResponse(
-        io.BytesIO(buffer_stream.getvalue().to_pybytes())
+    return PlainTextResponse(
+        buffer_stream.getvalue().to_pybytes()
     )
 
 
@@ -157,6 +157,6 @@ def stream_result_fixed(input_query: InputFixedQuery,
     result_data = processor.process_fixed_request(input_query)
     buffer_stream = pa.BufferOutputStream()
     pq.write_table(result_data, buffer_stream)
-    return StreamingResponse(
-        io.BytesIO(buffer_stream.getvalue().to_pybytes())
+    return PlainTextResponse(
+        buffer_stream.getvalue().to_pybytes()
     )


### PR DESCRIPTION
# FASTER STREAMING ENDPOINTS

The newly implemented streaming endpoints are painfully slow with big files.
Read up a bit and it seemed like it is not uncommon to use starlette PlainTextResponse to respond with a binaryfile content as a bytestring.
I implemented this locally and tested it with a 432MB parquet file. I received the file and opened it in pandas to ensure it arrived in full.

The file was downloaded in 11 seconds, with a download speed of 39,4MB/s.
This pretty much solves all problems with inefficiencies of distributed data-services, and I want to test this in production as well.