### PR TITLE
Fix logging in elk

### DIFF
--- a/application.py
+++ b/application.py
@@ -141,6 +141,10 @@ class CustomJSONRequestLogFormatter(json_logging.JSONRequestLogFormatter):
         json_log_object["responseTime"] = json_log_object.pop('response_time_ms')
         json_log_object["statusCode"] = json_log_object.pop('response_status')
 
+        json_log_object["schemaVersion"] = "v3"
+        json_log_object["serviceVersion"] = str(pkg_meta['version'])
+        json_log_object["serviceName"] = "data-service"
+
         del json_log_object['written_ts']
         del json_log_object['type']
         del json_log_object['remote_user']
@@ -186,6 +190,7 @@ async def unknown_exception_handler(request, exc):
 
 @data_service_app.on_event("startup")
 def startup_event():
+    json_logging.CREATE_CORRELATION_ID_IF_NOT_EXISTS = False
     json_logging.init_fastapi(enable_json=True, custom_formatter=CustomJSONLog)
     json_logging.init_request_instrument(data_service_app, custom_formatter=CustomJSONRequestLogFormatter)
 

--- a/data_service/api/data_api.py
+++ b/data_service/api/data_api.py
@@ -1,22 +1,17 @@
 import logging
-import os
-import io
-from fastapi import APIRouter, Depends, Header
-from fastapi.responses import PlainTextResponse
-from fastapi import HTTPException, status
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+from fastapi import APIRouter, Depends, Header
+from fastapi.responses import PlainTextResponse
 
+from data_service.api.auth import authorize_user
 from data_service.api.query_models import (
     InputTimePeriodQuery, InputTimeQuery, InputFixedQuery
 )
-from data_service.config import config
 from data_service.api.response_models import ErrorMessage
-from data_service.config.config import get_settings
 from data_service.config.dependencies import get_processor
 from data_service.core.processor import Processor
-from data_service.api.auth import authorize_user
 
 data_router = APIRouter()
 log = logging.getLogger(__name__)

--- a/data_service/core/processor.py
+++ b/data_service/core/processor.py
@@ -79,7 +79,7 @@ class Processor:
                 if filepath.endswith(".parquet"):
                     self.__log_parquet_details__(filepath)
                     # Log just the first file
-                    break
+                    return
 
     def __log_parquet_details__(self, parquet_file):
         self.log.info(

--- a/data_service/core/processor.py
+++ b/data_service/core/processor.py
@@ -78,6 +78,8 @@ class Processor:
                 filepath = subdir + os.sep + filename
                 if filepath.endswith(".parquet"):
                     self.__log_parquet_details__(filepath)
+                    # Log just the first file
+                    break
 
     def __log_parquet_details__(self, parquet_file):
         self.log.info(

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -1,0 +1,24 @@
+import json_logging
+from fastapi.testclient import TestClient
+
+from application import data_service_app
+
+json_logging.init_fastapi(enable_json=True)
+client = TestClient(data_service_app)
+
+
+def test_client_sends_x_request_id():
+    response = client.get(
+        "/health/alive",
+        headers={"X-Request-ID": "abc123"}
+    )
+    assert response.status_code == 200
+    assert "abc123" == response.headers["X-Request-ID"]
+
+
+def test_client_does_not_send_x_request_id():
+    response = client.get(
+        "/health/alive"
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"]

--- a/tests/unit/api/test_data_api.py
+++ b/tests/unit/api/test_data_api.py
@@ -1,17 +1,15 @@
-import pytest
+from unittest.mock import Mock
+
 import pyarrow as pa
 import pyarrow.parquet as pq
-
-from unittest.mock import Mock
+import pytest
 from fastapi.testclient import TestClient
 
 from application import data_service_app
 from data_service.config import config, dependencies
 from data_service.core.processor import Processor
-
-from tests.unit.util.util import generate_RSA_key_pairs, encode_jwt_payload
 from tests.resources import test_data
-
+from tests.unit.util.util import generate_RSA_key_pairs, encode_jwt_payload
 
 JWT_PRIVATE_KEY, JWT_PUBLIC_KEY = generate_RSA_key_pairs()
 JWT_INVALID_PRIVATE_KEY, _ = generate_RSA_key_pairs()


### PR DESCRIPTION
- add necessary fields for request logging so that they will not be filtered out by Logstash
- use same behaviour as Datastore-API - only log incoming X-Request-ID, don't create a new one
- lower amount of logging for parititioned parquet dataset