### PR TITLE
Bugfix in calculating 3-parts version number.

### DIFF
--- a/data_service/adapters/storage/local.py
+++ b/data_service/adapters/storage/local.py
@@ -44,13 +44,15 @@ class LocalFileAdapter(FileAdapter):
         return full_path
 
     def __get_data_versions__(self, version: str) -> str:
-
-        if version.count('.') > 2:
-            version = '.'.join(version.split('.')[:-1])
-        version = version.replace('.', '_')
-
+        version = self.__to_underscored_version__(version)
         data_versions_file = (
             f"{self.settings.DATASTORE_DIR}/datastore/data_versions__{version}.json"
         )
         with open(data_versions_file, encoding="utf-8") as f:
             return json.load(f)
+
+    def __to_underscored_version__(self, version: str) -> str:
+        if version.count('.') > 2:
+            version = '.'.join(version.split('.')[:-1])
+        version = version.replace('.', '_')
+        return version

--- a/data_service/adapters/storage/local.py
+++ b/data_service/adapters/storage/local.py
@@ -27,8 +27,7 @@ class LocalFileAdapter(FileAdapter):
             )
             full_path = full_path if os.path.isdir(full_path) else f"{full_path}.parquet"
         else:
-            version_underscored = version.replace('.', '_')[:5]
-            data_versions = self.__get_data_versions__(version_underscored)
+            data_versions = self.__get_data_versions__(version)
             if data_structure_name not in data_versions:
                 raise NotFoundException(
                     f"No such data structure in data_versions file for version {version}")
@@ -44,9 +43,14 @@ class LocalFileAdapter(FileAdapter):
 
         return full_path
 
-    def __get_data_versions__(self, version_underscored: str) -> str:
+    def __get_data_versions__(self, version: str) -> str:
+
+        if version.count('.') > 2:
+            version = '.'.join(version.split('.')[:-1])
+        version = version.replace('.', '_')
+
         data_versions_file = (
-            f"{self.settings.DATASTORE_DIR}/datastore/data_versions__{version_underscored}.json"
+            f"{self.settings.DATASTORE_DIR}/datastore/data_versions__{version}.json"
         )
         with open(data_versions_file, encoding="utf-8") as f:
             return json.load(f)

--- a/tests/unit/storage/test_local.py
+++ b/tests/unit/storage/test_local.py
@@ -1,7 +1,6 @@
 from data_service.adapters.storage.local import LocalFileAdapter
 from data_service.config import config
 
-
 local_file_adapter = LocalFileAdapter(
     settings=config.LocalFileSettings(
         DATASTORE_DIR='tests/resources/datastore_unit_test',
@@ -10,9 +9,15 @@ local_file_adapter = LocalFileAdapter(
 
 def test_get_file_path():
     assert local_file_adapter.get_parquet_file_path("TEST_PERSON_INCOME", "0.0.0.1") \
-            == "tests/resources/datastore_unit_test/data/TEST_PERSON_INCOME/TEST_PERSON_INCOME__0_0.parquet"
+           == "tests/resources/datastore_unit_test/data/TEST_PERSON_INCOME/TEST_PERSON_INCOME__0_0.parquet"
 
 
 def test_get_file_path_draft():
     assert local_file_adapter.get_parquet_file_path("TEST_PERSON_INCOME", "draft") \
-            == "tests/resources/datastore_unit_test/data/TEST_PERSON_INCOME/TEST_PERSON_INCOME__0_0.parquet"
+           == "tests/resources/datastore_unit_test/data/TEST_PERSON_INCOME/TEST_PERSON_INCOME__0_0.parquet"
+
+
+def test_to_underscored_version():
+    assert "13_0_0" == local_file_adapter.__to_underscored_version__("13.0.0.0")
+    assert "1_0_0" == local_file_adapter.__to_underscored_version__("1.0.0.0")
+    assert "2_0_0" == local_file_adapter.__to_underscored_version__("2.0.0")


### PR DESCRIPTION
A bug caused version = 13.0.0.0 to be converted to 13_0_

The new code makes conversions as follows:
13.0.0.0 --> 13_0_0
1.0.0.0 --> 1_0_0
2.0.0 --> 2_0_0
