### PR TITLE
Fix failing tests on windows

### DIFF
--- a/tests/unit/core/test_processor.py
+++ b/tests/unit/core/test_processor.py
@@ -103,5 +103,5 @@ def result_set_to_csv_string(file_name):
 
 def parquet_table_to_csv_string(table):
     data_frame = table.to_pandas()
-    csv_string = data_frame.to_csv(sep=';', encoding='utf-8')
+    csv_string = data_frame.to_csv(sep=';', encoding='utf-8', line_terminator='\n')
     return csv_string


### PR DESCRIPTION
Issue was caused by the data frame containing embedded
carrriage return characters (Note: purely windows specfic)