### PR TITLE
Log only length of population

### DIFF
--- a/data_service/api/query_models.py
+++ b/data_service/api/query_models.py
@@ -21,7 +21,7 @@ class InputQuery(BaseModel):
         return version
 
     def __str__(self) -> str:
-        temp: InputQuery = copy.copy(self)
+        temp: InputQuery = copy.deepcopy(self)
         if temp.population:
             temp.population = f"<length: {len(temp.population)}>"
         return super(InputQuery, temp).__str__()

--- a/data_service/api/query_models.py
+++ b/data_service/api/query_models.py
@@ -1,3 +1,4 @@
+import copy
 import re
 from typing import Optional
 
@@ -18,6 +19,12 @@ class InputQuery(BaseModel):
                 f"'{version}' is not a valid semantic version."
             )
         return version
+
+    def __str__(self) -> str:
+        temp: InputQuery = copy.copy(self)
+        if temp.population:
+            temp.population = f"<length: {len(temp.population)}>"
+        return super(InputQuery, temp).__str__()
 
 
 class InputTimePeriodQuery(InputQuery):

--- a/tests/unit/api/test_query_models.py
+++ b/tests/unit/api/test_query_models.py
@@ -109,12 +109,13 @@ def test_population_to_string():
         "version": "1.0.0.0",
         "population": [1, 2, 3]
     }
-    assert str(InputQuery.parse_obj(data)) == \
+    actual: InputQuery = InputQuery.parse_obj(data)
+    assert str(actual) == \
         "dataStructureName='DATASET_NAME' " \
         "version='1.0.0.0' " \
         "population='<length: 3>' " \
         "includeAttributes=False"
-
+    assert actual.population == data["population"]
 
 def test_population_to_string_input_time_query():
     data = {
@@ -123,9 +124,11 @@ def test_population_to_string_input_time_query():
         "population": [1, 2, 3],
         "date": 1900
     }
-    assert str(InputTimeQuery.parse_obj(data)) == \
+    actual: InputTimeQuery = InputTimeQuery.parse_obj(data)
+    assert str(actual) == \
            "dataStructureName='DATASET_NAME' " \
            "version='1.0.0.0' " \
            "population='<length: 3>' " \
            "includeAttributes=False " \
            "date=1900"
+    assert actual.population == data["population"]

--- a/tests/unit/api/test_query_models.py
+++ b/tests/unit/api/test_query_models.py
@@ -1,8 +1,9 @@
-import pytest
 from typing import List
 
+import pytest
+
 from data_service.api.query_models import (
-    InputTimeQuery, InputTimePeriodQuery, InputFixedQuery
+    InputTimeQuery, InputTimePeriodQuery, InputFixedQuery, InputQuery
 )
 
 
@@ -100,3 +101,31 @@ def test_create_and_validate_input_fixed_query_with_error():
     }
     with pytest.raises(ValueError):
         InputFixedQuery.parse_obj(data)
+
+
+def test_population_to_string():
+    data = {
+        "dataStructureName": "DATASET_NAME",
+        "version": "1.0.0.0",
+        "population": [1, 2, 3]
+    }
+    assert str(InputQuery.parse_obj(data)) == \
+        "dataStructureName='DATASET_NAME' " \
+        "version='1.0.0.0' " \
+        "population='<length: 3>' " \
+        "includeAttributes=False"
+
+
+def test_population_to_string_input_time_query():
+    data = {
+        "dataStructureName": "DATASET_NAME",
+        "version": "1.0.0.0",
+        "population": [1, 2, 3],
+        "date": 1900
+    }
+    assert str(InputTimeQuery.parse_obj(data)) == \
+           "dataStructureName='DATASET_NAME' " \
+           "version='1.0.0.0' " \
+           "population='<length: 3>' " \
+           "includeAttributes=False " \
+           "date=1900"

--- a/tests/unit/api/test_query_models.py
+++ b/tests/unit/api/test_query_models.py
@@ -117,6 +117,7 @@ def test_population_to_string():
         "includeAttributes=False"
     assert actual.population == data["population"]
 
+
 def test_population_to_string_input_time_query():
     data = {
         "dataStructureName": "DATASET_NAME",


### PR DESCRIPTION
Creates a copy of the Pydantic object to be able to change field value for logging without changing the original object.