### PR TITLE
Removed EmptyResultSetException

### DIFF
--- a/application.py
+++ b/application.py
@@ -20,7 +20,6 @@ from data_service.api.data_api import data_router
 from data_service.api.observability_api import observability_router
 from data_service.config.logging_config import \
     CustomJSONLog, CustomJSONRequestLogFormatter
-from data_service.core.filters import EmptyResultSetException
 from data_service.exceptions import NotFoundException
 
 # Self-hosting JavaScript and CSS for docs
@@ -87,16 +86,6 @@ async def redoc_html():
         openapi_url=data_service_app.openapi_url,
         title=data_service_app.title + " - ReDoc",
         redoc_js_url="/static/redoc.standalone.js",
-    )
-
-
-@data_service_app.exception_handler(EmptyResultSetException)
-async def empty_result_set_exception_handler(
-    request,  # pylint: disable=unused-argument
-    exc):
-    logger.exception(exc)
-    return Response(
-        status_code=status.HTTP_204_NO_CONTENT
     )
 
 

--- a/data_service/core/filters.py
+++ b/data_service/core/filters.py
@@ -85,12 +85,4 @@ def do_filter(
         my_dataset = ds.dataset(parquet_partition_name)
         table = my_dataset.to_table(
             filter=table_filter, columns=columns_excluding_attributes)
-
-    if table and table.num_rows > 0:
-        return table
-
-    raise EmptyResultSetException("Empty result set")
-
-
-class EmptyResultSetException(Exception):
-    pass
+    return table

--- a/data_service/core/filters.py
+++ b/data_service/core/filters.py
@@ -3,6 +3,8 @@ import logging
 import pyarrow.dataset as ds
 from pyarrow import Table
 
+logger = logging.getLogger()
+
 columns_including_attributes = [
     "unit_id", "value", "start_epoch_days", "stop_epoch_days"
 ]
@@ -85,4 +87,8 @@ def do_filter(
         my_dataset = ds.dataset(parquet_partition_name)
         table = my_dataset.to_table(
             filter=table_filter, columns=columns_excluding_attributes)
+
+    if table.num_rows == 0:
+        logger.info("Empty result set")
+
     return table

--- a/data_service/core/filters.py
+++ b/data_service/core/filters.py
@@ -88,7 +88,5 @@ def do_filter(
         table = my_dataset.to_table(
             filter=table_filter, columns=columns_excluding_attributes)
 
-    if table.num_rows == 0:
-        logger.info("Empty result set")
-
+    logger.info(f'Number of rows in result set: {table.num_rows}')
     return table

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -138,6 +138,22 @@ def test_by_time():
     )
 
 
+def test_empty_result_set_with_attributes():
+    actual = filter_by_time(TEST_BOSTED_PARQUET_DIR, 1, None, True)
+    print_actual(actual)
+
+    assert (actual.num_columns == 4)
+    assert (actual.num_rows == 0)
+
+
+def test_empty_result_set_without_attributes():
+    actual = filter_by_time(TEST_BOSTED_PARQUET_DIR, 1, None, False)
+    print_actual(actual)
+
+    assert (actual.num_columns == 2)
+    assert (actual.num_rows == 0)
+
+
 def test_by_time_excluding_attributes():
     expected = Table.from_pydict({
         'unit_id': [1000000002, 1000000004, 1000000003, 1000000001],

--- a/tests/unit/core/test_processor.py
+++ b/tests/unit/core/test_processor.py
@@ -2,9 +2,9 @@ import os
 
 import pyarrow.parquet as pq
 import pytest
+from pyarrow import Table
 
 from data_service.config import config
-from data_service.core.filters import EmptyResultSetException
 from data_service.core.processor import (
     Processor
 )
@@ -40,12 +40,13 @@ def test_valid_event_request_partitioned():
     )
 
 
-def test_invalid_event_request():
-    with pytest.raises(EmptyResultSetException) as e:
-        processor.process_event_request(
-            test_data.INVALID_EVENT_QUERY_INVALID_STOP_DATE
-        )
-    assert str(e.value) == "Empty result set"
+def test_event_request_causing_empty_result():
+    data = processor.process_event_request(
+        test_data.INVALID_EVENT_QUERY_INVALID_STOP_DATE
+    )
+    assert isinstance(data, Table)
+    assert (data.num_columns == 2)
+    assert (data.num_rows == 0)
 
 
 def test_valid_status_request():


### PR DESCRIPTION
An empty pyarrow table is returned when parquet filtering results in zero rows.