### PR TITLE
Port configuration

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ CONFIG_PROFILE=LOCAL
 STACK=local
 JWKS_URL=http://dummy
 DOCKER_HOST_NAME=localhost
+PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,4 @@ RUN pip install -r requirements.txt
 #the output is sent straight to terminal without being first buffered
 ENV PYTHONUNBUFFERED 1
 
-CMD [ "uvicorn", "--host=0.0.0.0", "application:data_service_app"]
-
+CMD [ "python", "application.py"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ docker run --publish 8000:8000 \
 --env JWKS_URL=<URL here> \
 --env STACK=<dev | qa | prod> \
 --env JWT_AUTH=true \
+--env PORT=8000 \
 --env DOCKER_HOST_NAME=localhost \
 -v /path/datastore:/datastore_path \
 -v /path/resultset:/resultset_path data-service

--- a/application.py
+++ b/application.py
@@ -16,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 
+from data_service.config import environment
 from data_service.api.data_api import data_router
 from data_service.api.observability_api import observability_router
 from data_service.config.logging_config import \
@@ -129,4 +130,4 @@ def startup_event():
 
 
 if __name__ == "__main__":
-    uvicorn.run(data_service_app, host="0.0.0.0", port=8000)
+    uvicorn.run(data_service_app, host="0.0.0.0", port=environment.get('PORT'))

--- a/data_service/config/environment.py
+++ b/data_service/config/environment.py
@@ -1,0 +1,15 @@
+import os
+
+
+def _initialize_environment() -> dict:
+    return {
+        'PORT': int(os.environ['PORT']),
+        'DOCKER_HOST_NAME': os.environ['DOCKER_HOST_NAME']
+    }
+
+
+_ENVIRONMENT_VARIABLES = _initialize_environment()
+
+
+def get(key: str) -> str:
+    return _ENVIRONMENT_VARIABLES[key]

--- a/data_service/config/logging_config.py
+++ b/data_service/config/logging_config.py
@@ -5,6 +5,8 @@ import sys
 import json_logging
 import tomlkit
 
+from data_service.config import environment
+
 
 def _get_project_meta():
     with open('./pyproject.toml') as pyproject:
@@ -15,7 +17,7 @@ def _get_project_meta():
 
 pkg_meta = _get_project_meta()
 service_name = "data-service"
-host = os.environ['DOCKER_HOST_NAME']
+host = environment.get('DOCKER_HOST_NAME')
 command = json.dumps(sys.argv)
 
 


### PR DESCRIPTION
# PORT CONFIGURATION

Application port is configurable through environment. Couldn't make it work with the environment variable mentioned [here](https://www.uvicorn.org/settings/). (It is also omitted from [this settings page](https://www.uvicorn.org/#config-and-server-instances) so maybe the docs are outdated?)

Decided to run the uvicorn instance directly from the python script as this already was done for the purposes of running the app from IDEA. 
Tested the new docker image with the datastore-testing repo 👍🏻 


### Note
Should we refactor this app somewhat? It is set up very differently from our other APIs. There used to be a reason for this, but we have now removed the cloud bits. I would like to refactor it to be more similar to our other APIs to reduce complexity when dealing with the whole stack. Thoughts?