### PR TITLE
Bugfix init logging

### DIFF
--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -1,9 +1,7 @@
-import json_logging
 from fastapi.testclient import TestClient
 
 from data_service.app import data_service_app
 
-json_logging.init_fastapi(enable_json=True)
 client = TestClient(data_service_app)
 
 


### PR DESCRIPTION
With the new FastAPI and Starlette, the json_logging cannot initialize a middleware after the application is up, so now the initialization takes place before the app starts.