### PR TITLE
Fix type population

### DIFF
--- a/data_service/api/query_models.py
+++ b/data_service/api/query_models.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, validator
 class InputQuery(BaseModel):
     dataStructureName: str
     version: str
-    population: Optional[list[int]]
+    population: Optional[list]
     includeAttributes: Optional[bool] = False
 
     @validator("version")

--- a/tests/unit/api/test_query_models.py
+++ b/tests/unit/api/test_query_models.py
@@ -39,6 +39,29 @@ def test_create_and_validate_full_input_time_period_query():
     assert actual.includeAttributes is True
 
 
+def test_no_population_type_coercion():
+    data = {
+        "dataStructureName": "DATASET_NAME",
+        "version": "1.0.0.0",
+        "startDate": 1964,
+        "stopDate": 2056,
+        "population": [1, 2, 3],
+        "includeAttributes": True,
+    }
+    actual = InputTimePeriodQuery.parse_obj(data)
+    assert actual.population == data["population"]
+    data = {
+        "dataStructureName": "DATASET_NAME",
+        "version": "1.0.0.0",
+        "startDate": 1964,
+        "stopDate": 2056,
+        "population": ["1", "2", "3"],
+        "includeAttributes": True,
+    }
+    actual = InputTimePeriodQuery.parse_obj(data)
+    assert actual.population == data["population"]
+
+
 def test_create_and_validate_input_time_period_query_with_error():
     data = {
         "dataStructureName": "DATASET_NAME",


### PR DESCRIPTION
our model made the population always be read into an integer. When the json list items were quoted pydantic coerces the type to an integer. 
Surprisingly, if we add a Union type accepting both strings and integers, pydantic coerces the list into the type that is mentioned first in the union type:

```py
population: Optional[list[Union[str, int]]]
```
_Example: this would coerce a list without quotes to strings even if they are given as integers_

The only way I found to make pydantic respect the original type was to not type the contents of the list at all. Leaving the responsiblity of typing to the requestee, which in this case is the SIKT importer.