### PR TITLE
MICNO-307: Change logs for LocalProtocolError from error to warning

### DIFF
--- a/data_service/app.py
+++ b/data_service/app.py
@@ -12,6 +12,7 @@ from fastapi.openapi.docs import (
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import PlainTextResponse
+from h11._util import LocalProtocolError
 
 from data_service.config import environment
 from data_service.api.data_api import data_router
@@ -88,6 +89,15 @@ async def not_found_exception_handler(exc):
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,
         content=jsonable_encoder({"detail": "No such datastructure"}),
+    )
+
+
+@data_service_app.exception_handler(LocalProtocolError)
+async def local_protocol_error_handler(exc: LocalProtocolError):
+    logger.warning(exc, exc_info=True)
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content=jsonable_encoder({"detail": "Protocol violation"}),
     )
 
 


### PR DESCRIPTION
I have not added specific handling for HTTPErrors raised by FastAPI/Starlette since we have not experienced any ERROR logging connected to this. Let me know if you think I should add this still.